### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/cn.json
+++ b/languages/cn.json
@@ -51,8 +51,7 @@
 			},
 			"autorecUpdate": {
 				"name": "自动识别文件更新",
-				"label": "更新文件",
-				"hint": "检查是否有动画的更新可用？"
+				"label": "更新文件"
 			}
 		},
 		"macro": {

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -49,8 +49,7 @@
 			},
 			"autorecUpdate": {
 				"name": "Mise à jour du menu de l'auto-reconnaissance",
-				"label": "Menu de mise à jour",
-				"hint": "Vérifiez s'il y a des mises à jour à apporter à vos animations ?"
+				"label": "Menu de mise à jour"
 			},
 			"autoUpdate": {
 				"name": "Ouvrir le menu de mise à jour lors de la mise à jour du module",

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -42,8 +42,7 @@
 			},
 			"autorecUpdate": {
 				"name": "Aktualizacja Menu Auto-Rozpoznawania",
-				"label": "Menu Aktualizacji",
-				"hint": "Sprawdź czy nie ma aktualizacji dla twoich animacji?"
+				"label": "Menu Aktualizacji"
 			},
 			"allowUncommonSummons": {
 				"name": "Pozwól na Rzadkie Przywołania",


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [PF2e Animation Macros/main](https://weblate.foundryvtt-hub.com/projects/pf2e-animations/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/pf2e-animations/-/main/horizontal-auto.svg)