### PR TITLE
Fix absolute vs relative link bug in module thumbnail image

### DIFF
--- a/module.json
+++ b/module.json
@@ -162,7 +162,7 @@
         },
         {
             "type": "setup",
-            "url": "/modules/pf2e-jb2a-macros/cover.png"
+            "url": "modules/pf2e-jb2a-macros/cover.png"
         },
         {
             "type": "cover",


### PR DESCRIPTION
URLs of module assets should not start with `/` (forward backslash), it should be skipped.  When it is included, the image only loads successfully in localhost and in servers that set it up to be in e.g. `www.example.com` but not `www.example.com/myfoundryinstall`.