### PR TITLE
Fix integration bug with Modifiers Matter (empty animations were played)

### DIFF
--- a/module/modifiers-matter.js
+++ b/module/modifiers-matter.js
@@ -24,7 +24,7 @@ self.pf2eAnimations.modifiersMatter = Hooks.on("modifiersMatter", ({
             animationName = `Modifiers Matter: ${name}`
         }
 
-        if (!name) {
+        if (!animationName) {
             return pf2eAnimations.debug(`Modifiers Matter | No Animation Found for:`, `${name} (${significance})`);
         } else {
             AutomatedAnimations.playAnimation(


### PR DESCRIPTION
This prevents error messages from appearing in the console each time MM triggers while this module is active.  (except when Bless causes an MM improvement, because that's the one animation that does exist)