### PR TITLE
Fix Sudden Charge and Dimension Door

### DIFF
--- a/build/macros/Dimension Door.js
+++ b/build/macros/Dimension Door.js
@@ -5,7 +5,7 @@ if (!game.modules.get("jb2a_patreon")?.active) {
 
 const [tokenD, tokenScale] = await pf2eAnimations.macroHelpers(args)
 
-let spellLevel = args[0]?.data?.flags?.pf2e?.casting?.level ?? 11
+let spellLevel = args[0]?.item?.level ?? 11
 
 if (spellLevel === 11 && args.length !== 0)
   pf2eAnimations.debug(
@@ -20,7 +20,10 @@ const location = await pf2eAnimations.crosshairs(
   { range, openSheet: false, noCollision: spellLevel < 5 }
 )
 
-if (!location) return
+if (!location || location.cancelled) {
+  tokenD.actor.sheet.maximize()
+  return
+}
 
 await Sequencer.Preloader.preloadForClients([
   "jb2a.magic_signs.rune.conjuration.intro.blue",

--- a/build/macros/Sudden Charge.js
+++ b/build/macros/Sudden Charge.js
@@ -15,19 +15,21 @@ for (let i = 0; i < 2; i++) {
     { tokenD },
     {
       crosshairConfig: {
-        label:
-          `${game.i18n.localize(
-            "pf2e-jb2a-macros.macro.suddenCharge.suddenCharge"
-          )} ` +
-          (i + 1),
+        label: `${game.i18n.localize(
+          "pf2e-jb2a-macros.macro.suddenCharge.suddenCharge"
+        )} (${i + 1}/2)`,
       },
       noCollisionType: "move",
+      openSheet: false,
     }
   )
 
   console.log(location)
 
-  if (location === false || location.cancelled) return
+  if (location === false || location.cancelled) {
+    tokenD.actor.sheet.maximize()
+    return
+  }
 
   await new Sequence({ moduleName: "PF2e Animations", softFail: true })
     .animation()
@@ -47,6 +49,7 @@ for (let i = 0; i < 2; i++) {
     .belowTokens()
     .fadeOut(1000)
     .scale(0.5 * tokenD.document.height)
+    .waitUntilFinished()
     .play()
 }
 

--- a/languages/cn.json
+++ b/languages/cn.json
@@ -81,7 +81,7 @@
 		"macro": {
 			"suddenCharge": {
 				"notif": "突袭冲锋！选择你想去的位置。右键取消。",
-				"suddenCharge": "突袭冲锋。"
+				"suddenCharge": "突袭冲锋"
 			},
 			"disguise": {
 				"illusoryDisguise": "🎭幻象伪装🎭",

--- a/languages/de.json
+++ b/languages/de.json
@@ -30,7 +30,7 @@
 		"macro": {
 			"suddenCharge": {
 				"notif": "Plötzliche Attacke! Wählen Sie aus, wohin Sie sich bewegen wollen. Rechtsklick zum Abbrechen.",
-				"suddenCharge": "Plötzlicher Angriff."
+				"suddenCharge": "Plötzlicher Angriff"
 			},
 			"disguise": {
 				"humanoidForm": "🎭Humanoide Form🎭",

--- a/languages/en.json
+++ b/languages/en.json
@@ -32,7 +32,7 @@
 			"outOfRange": "Out of Range!",
 			"suddenCharge": {
 				"notif": "Sudden Charge! Select where you want to move. Right click to cancel.",
-				"suddenCharge": "Sudden Charge."
+				"suddenCharge": "Sudden Charge"
 			},
 			"disguise": {
 				"humanoidForm": "🎭Humanoid Form🎭",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -81,7 +81,7 @@
 		"macro": {
 			"suddenCharge": {
 				"notif": "Charge soudaine ! Choisissez où vous voulez vous déplacer. Clic droit pour annuler.",
-				"suddenCharge": "Charge soudaine."
+				"suddenCharge": "Charge soudaine"
 			},
 			"disguise": {
 				"humanoidForm": "🎭Forme humanoïde🎭",

--- a/languages/it.json
+++ b/languages/it.json
@@ -29,7 +29,7 @@
 		},
 		"macro": {
 			"suddenCharge": {
-				"suddenCharge": "Carica Improvvisa.",
+				"suddenCharge": "Carica Improvvisa",
 				"notif": "Carica Improvvisa! Seleziona dove vuoi moverti. Tasto destro per annullare."
 			},
 			"disguise": {

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -119,7 +119,7 @@
 			},
 			"suddenCharge": {
 				"notif": "Nagła Szarża! Wybierz gdzie chcesz się poruszyć. Kliknij prawy przycisk aby anulować.",
-				"suddenCharge": "Nagła Szarża."
+				"suddenCharge": "Nagła Szarża"
 			},
 			"outOfRange": "Poza zasięgiem!"
 		},

--- a/languages/zh-tw.json
+++ b/languages/zh-tw.json
@@ -55,7 +55,7 @@
 		"macro": {
 			"suddenCharge": {
 				"notif": "突襲衝鋒！選擇你想去的位置。右鍵取消。",
-				"suddenCharge": "突襲衝鋒。"
+				"suddenCharge": "突襲衝鋒"
 			},
 			"disguise": {
 				"illusoryDisguise": "🎭幻象偽裝🎭",

--- a/module/pf2e-animations.js
+++ b/module/pf2e-animations.js
@@ -565,7 +565,7 @@ pf2eAnimations.runMacro = async function runJB2Apf2eMacro(
 
     if (macro_data) {
       if (isNewerVersion(game.version, "11")) {
-        await macro_data.execute({args});
+        await macro_data.execute({ args });
       } else {
         const temp_macro = new Macro(macro_data.toObject());
         temp_macro.ownership.default = CONST.DOCUMENT_PERMISSION_LEVELS.OWNER;
@@ -825,7 +825,7 @@ pf2eAnimations.crosshairs = async function crosshairs(
       // make it wait or go into an unescapable infinite loop of pain
       await warpgate.wait(50);
 
-      const ray = new Ray(args.token.center, crosshairs);
+      const ray = new Ray((args.token ?? args.tokenD).center, crosshairs);
 
       const distance = canvas.grid.measureDistances([{ ray }], {
         gridSpaces: true,
@@ -879,6 +879,10 @@ pf2eAnimations.crosshairs = async function crosshairs(
 
           await Sequencer.EffectManager.endEffects({ name: "Out of Range!" });
         }
+
+        if (opts.crosshairConfig?.label)
+          crosshairs.label += `\n${opts.crosshairConfig.label}`;
+
         crosshairs.draw();
       }
     }


### PR DESCRIPTION
- Sudden Charge would freeze foundry for all users. Waiting until the first step is completed before starting the second seems to fix it. (#186)
- Dimension Door was using an old property both for spell level
- Stopped the inFlight loop from overriding the label. If one is set, it's now appended instead,
  - This only mattered for sudden charge, so I changed the localized text to no longer contain punctuation
- Updated both macros to properly handle canceling the crosshair and reopening the sheet 