### PR TITLE
Fix v14 compatibility: namespaced foundry.utils + removed canvas APIs

### DIFF
--- a/module.json
+++ b/module.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/MrVauxs/pf2e-jb2a-macros",
     "compatibility": {
         "minimum": "11",
-        "verified": "13"
+        "verified": "14"
     },
     "esmodules": [
         "module/settings.js",

--- a/module/pf2e-animations.js
+++ b/module/pf2e-animations.js
@@ -118,10 +118,17 @@ pf2eAnimations.hooks.ready = Hooks.once("ready", () => {
     game.settings.set("pf2e-jb2a-macros", "tmfx", false);
 });
 
+// V13 renamed renderChatMessage → renderChatMessageHTML and changed the second
+// argument from a jQuery wrapper to a raw HTMLElement. Listen on whichever the
+// running version exposes so we work on v11–v14 without tripping deprecations.
 pf2eAnimations.hooks.renderChatMessage = Hooks.on(
-  "renderChatMessage",
-  async (message, [html]) => {
-    for (const btn of html.querySelectorAll(
+  foundry.utils.isNewerVersion(game.version ?? "0", "12")
+    ? "renderChatMessageHTML"
+    : "renderChatMessage",
+  async (message, html) => {
+    const root = html instanceof HTMLElement ? html : html?.[0];
+    if (!root) return;
+    for (const btn of root.querySelectorAll(
       "button.pf2e-animations-settings-button"
     )) {
       btn.addEventListener("click", (event) => {
@@ -754,7 +761,7 @@ pf2eAnimations.crosshairs = async function crosshairs(
   }
 ) {
   pf2eAnimations.requireModule("warpgate");
-  opts = mergeObject(
+  opts = foundry.utils.mergeObject(
     {
       openSheet: true,
       noCollision: true,
@@ -801,7 +808,7 @@ pf2eAnimations.crosshairs = async function crosshairs(
     rememberControlled: true,
   };
 
-  mergeObject(crosshairConfig, opts.crosshairConfig);
+  foundry.utils.mergeObject(crosshairConfig, opts.crosshairConfig);
 
   crosshairConfig.ogIcon = crosshairConfig.icon;
 
@@ -820,27 +827,39 @@ pf2eAnimations.crosshairs = async function crosshairs(
         .play();
     }
 
+    // V13 namespaced Ray under foundry.canvas.geometry; v15 will remove the
+    // global. Prefer the namespaced class but fall back for v11/v12.
+    const RayClass = foundry.canvas?.geometry?.Ray ?? Ray;
+
     while (crosshairs.inFlight) {
       // make it wait or go into an unescapable infinite loop of pain
       await warpgate.wait(50);
 
-      const ray = new Ray((args.token ?? args.tokenD).center, crosshairs);
+      const ray = new RayClass((args.token ?? args.tokenD).center, crosshairs);
 
-      const distance = canvas.grid.measureDistances([{ ray }], {
-        gridSpaces: true,
-      })[0];
+      // V12 deprecated grid.measureDistances in favour of measurePath; V14 removed it.
+      const distance = canvas.grid.measurePath
+        ? canvas.grid.measurePath([ray.A, ray.B]).distance
+        : canvas.grid.measureDistances([{ ray }], { gridSpaces: true })[0];
 
       // Only update if the distance has changed
       if (cachedDistance !== distance) {
         cachedDistance = distance;
         crosshairs.label = `${distance} ft.`;
-        if (
-          distance > opts.range ||
-          (opts.noCollision
-            ? canvas.walls.checkCollision(ray, { type: opts.noCollisionType })
-              .length
-            : false)
-        ) {
+        // V13 removed canvas.walls.checkCollision; collision checks now go
+        // through CONFIG.Canvas.polygonBackends.<type>.testCollision.
+        const collides = (() => {
+          if (!opts.noCollision) return false;
+          const backend = CONFIG.Canvas?.polygonBackends?.[opts.noCollisionType];
+          if (backend) {
+            return backend.testCollision(ray.A, ray.B, {
+              type: opts.noCollisionType,
+              mode: "any",
+            });
+          }
+          return canvas.walls.checkCollision(ray, { type: opts.noCollisionType }).length > 0;
+        })();
+        if (distance > opts.range || collides) {
           crosshairs.icon = "icons/svg/hazard.svg";
           await crosshairs.document.updateSource({
             flags: {
@@ -894,8 +913,9 @@ pf2eAnimations.crosshairs = async function crosshairs(
   }
 
   // Calculate the rotation from the origin in degrees, up = 0
+  const RayClass = foundry.canvas?.geometry?.Ray ?? Ray;
   location.rotationFromOrigin =
-    (new Ray(tokenDoc.center, location).angle * 180) / Math.PI + 90;
+    (new RayClass(tokenDoc.center, location).angle * 180) / Math.PI + 90;
   if (location.rotationFromOrigin < 0) location.rotationFromOrigin += 360;
 
   pf2eAnimations.debug("Crosshairs", args, opts, location);

--- a/module/updateMenu.js
+++ b/module/updateMenu.js
@@ -204,7 +204,7 @@ class autorecUpdateFormApplication extends FormApplication {
     }
 
     static get defaultOptions() {
-        return mergeObject(super.defaultOptions, {
+        return foundry.utils.mergeObject(super.defaultOptions, {
             classes: ['form'],
             popOut: true,
             template: `modules/pf2e-jb2a-macros/module/autorecUpdateMenu.html`,


### PR DESCRIPTION
## Summary

Restore Foundry V14 compatibility for the three call sites that hard-fail under v14, and clean up the deprecation warnings the module currently emits in v13+. Every changed call site keeps a v11/v12 fallback so the `compatibility.minimum: "11"` contract is preserved.

## Why these specifically

`updateMenu.js` is the most user-visible failure: every time the module's version changes, `pf2e-animations.js` opens `new autorecUpdateFormApplication().render(true)`. Rendering invokes the `defaultOptions` getter, which calls bare `mergeObject(...)`. In v14 that global no longer exists (it lives only at `foundry.utils.mergeObject`), so the autorec update menu throws `ReferenceError` on every upgrade.

`crosshairs()` similarly uses bare `mergeObject`, plus `canvas.grid.measureDistances` (removed in v14 — only `canvas.grid.measurePath` remains in `public/scripts/foundry.mjs`) and `canvas.walls.checkCollision` (removed in v13 — `WallsLayer` no longer exposes it; collision tests now go through `CONFIG.Canvas.polygonBackends[type].testCollision`).

The remaining changes silence deprecation warnings that v14 still tolerates but v15 will not:
- `Ray` was namespaced under `foundry.canvas.geometry` in v13 and the global is scheduled for removal in v15 (per the `addBackwardsCompatibilityReferences` block in `foundry.mjs`, `since: 13, until: 15`).
- `renderChatMessage` was renamed to `renderChatMessageHTML` in v13 and the second hook argument changed from a jQuery wrapper to a raw `HTMLElement` (`since: 13, until: 15`).

## Changes

| File | Change |
|---|---|
| `module/updateMenu.js` | `mergeObject` → `foundry.utils.mergeObject` in `defaultOptions` |
| `module/pf2e-animations.js` | `mergeObject` → `foundry.utils.mergeObject` (×2 in `crosshairs`) |
| `module/pf2e-animations.js` | `new Ray(...)` → namespaced class with global fallback (×2) |
| `module/pf2e-animations.js` | `canvas.grid.measureDistances` → `canvas.grid.measurePath`, with v11 fallback |
| `module/pf2e-animations.js` | `canvas.walls.checkCollision` → `CONFIG.Canvas.polygonBackends[type].testCollision`, with v11/v12 fallback |
| `module/pf2e-animations.js` | `renderChatMessage` hook subscribed via version-detected name; handler accepts both `HTMLElement` and jQuery |
| `module.json` | `compatibility.verified` `"13"` → `"14"` (minimum stays at `"11"`) |

## Out of scope

`FormApplication` is still used in `settings.js`, `blacklistMenu.js`, and `updateMenu.js`. It is deprecated since v13 but only scheduled for removal in v16, and migrating to `ApplicationV2 + HandlebarsApplicationMixin` is a behavior-changing refactor — kept out of this minimal compat patch.

## What I actually verified

- `node --check` passes on every modified file (syntax-only)
- Each removed/renamed API was confirmed against `public/scripts/foundry.mjs` from a v14.360 install — `canvas.grid.measureDistances` no longer exists, `WallsLayer` no longer defines `checkCollision`, `mergeObject` is not in the globals exposed by `Object.assign(globalThis, {...})` or by `addBackwardsCompatibilityReferences`
- `foundry.utils.mergeObject` and `CONFIG.Canvas.polygonBackends[type].testCollision` exist and have the expected signatures
- **Not yet runtime-tested in a v14 world.** A maintainer / user with v14 + Automated Animations should confirm the autorec update menu opens without a console error after the patch
- The `crosshairs()` path is gated behind `requireModule("warpgate")`; warpgate is archived and most v13+ users have moved to portal-lib, so I had no live way to exercise that code