### PR TITLE
Foundry V14 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -52,8 +52,8 @@
     ],
     "url": "https://github.com/MrVauxs/pf2e-jb2a-macros",
     "compatibility": {
-        "minimum": "11",
-        "verified": "13"
+        "minimum": "12",
+        "verified": "14"
     },
     "esmodules": [
         "module/settings.js",

--- a/module/autorecUpdateMenu.html
+++ b/module/autorecUpdateMenu.html
@@ -1,11 +1,9 @@
 <div class="pf2e-animations-autorec-update">{{{literallyEverything}}}</div>
-<form class="flexcol">
-  <footer class="sheet-footer flexrow">
-    <button class="pf2e-animations-autorec-update-buttons" type="update" name="update">
-        <i class="fa fa-check"></i> {{localize 'Update'}}
-    </button>
-    <button class="pf2e-animations-autorec-update-buttons" type="cancel" name="cancel">
-        <i class="fa fa-xmark"></i> {{localize 'Cancel'}}
-    </button>
-  </footer>
-</form>
+<footer class="sheet-footer flexrow form-footer">
+  <button class="pf2e-animations-autorec-update-buttons" type="button" data-action="update">
+      <i class="fa fa-check"></i> {{localize 'Update'}}
+  </button>
+  <button class="pf2e-animations-autorec-update-buttons" type="button" data-action="cancel">
+      <i class="fa fa-xmark"></i> {{localize 'Cancel'}}
+  </button>
+</footer>

--- a/module/blacklistMenu.js
+++ b/module/blacklistMenu.js
@@ -1,57 +1,73 @@
-class BlacklistMenu extends FormApplication {
-  async getData() {
-    const settings = await game.settings.get("pf2e-jb2a-macros", "blacklist")
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+class BlacklistMenu extends HandlebarsApplicationMixin(ApplicationV2) {
+  static DEFAULT_OPTIONS = {
+    id: "blacklistMenu",
+    classes: ["pf2e-animations"],
+    tag: "form",
+    window: {
+      title: "Change Blacklist Settings",
+      contentClasses: ["standard-form"],
+    },
+    position: { width: 400, height: "auto" },
+    actions: {
+      save: BlacklistMenu._onSave,
+      saveUpdate: BlacklistMenu._onSaveUpdate,
+    },
+  };
+
+  static PARTS = {
+    body: {
+      template: "modules/pf2e-jb2a-macros/templates/blacklist.hbs",
+    },
+  };
+
+  async _prepareContext() {
+    const settings = await game.settings.get("pf2e-jb2a-macros", "blacklist");
 
     const disabledSections = settings.menu.reduce((acc, name) => {
-      acc[name] = true
-      return acc
-    }, {})
+      acc[name] = true;
+      return acc;
+    }, {});
 
-    const entries = settings.entries.join(", ")
+    const entries = settings.entries.join(", ");
 
     return {
       disabledSections,
       entries,
-    }
+    };
   }
 
-  activateListeners(html) {
-    html.find("button#save").on("click", () => this.submit(html, false))
-    html.find("button#save-update").on("click", () => this.submit(html, true))
-  }
-
-  async submit(html, updateAnimations) {
-    const disabledSections = []
-    html.find(`input[type="checkbox"]`).each((index, element) => {
-      if (element.checked) disabledSections.push(element.id.substr(8))
-    })
-    const entries = html
-      .find("textarea#anim-entries")
-      .val()
-      .split(",")
-      .map((s) => s.trim())
+  async _save(updateAnimations) {
+    const root = this.element;
+    const disabledSections = [];
+    root.querySelectorAll('input[type="checkbox"]').forEach((element) => {
+      if (element.checked) disabledSections.push(element.id.substr(8));
+    });
+    const entries = root
+      .querySelector("textarea#anim-entries")
+      .value.split(",")
+      .map((s) => s.trim());
 
     await game.settings.set("pf2e-jb2a-macros", "blacklist", {
       menu: disabledSections,
       entries,
-    })
+    });
 
     if (updateAnimations) {
-      new autorecUpdateFormApplication().render(true)
+      new autorecUpdateFormApplication().render(true);
     }
 
-    this.close()
+    return this.close();
   }
 
-  static get defaultOptions() {
-    return {
-      ...super.defaultOptions,
-      title: "Change Blacklist Settings",
-      id: "blacklistMenu",
-      template: "modules/pf2e-jb2a-macros/templates/blacklist.hbs",
-      width: 400,
-    }
+  static async _onSave(event, target) {
+    return this._save(false);
+  }
+
+  static async _onSaveUpdate(event, target) {
+    return this._save(true);
   }
 }
 
-pf2eAnimations.blacklistMenu = BlacklistMenu
+pf2eAnimations.blacklistMenu = BlacklistMenu;

--- a/module/pf2e-animations.js
+++ b/module/pf2e-animations.js
@@ -119,8 +119,8 @@ pf2eAnimations.hooks.ready = Hooks.once("ready", () => {
 });
 
 pf2eAnimations.hooks.renderChatMessage = Hooks.on(
-  "renderChatMessage",
-  async (message, [html]) => {
+  "renderChatMessageHTML",
+  async (message, html) => {
     for (const btn of html.querySelectorAll(
       "button.pf2e-animations-settings-button"
     )) {
@@ -289,14 +289,15 @@ pf2eAnimations.hooks.renderActorDirectory = Hooks.on(
   "renderActorDirectory",
   (app, html, data) => {
     if (!(game.user.isGM && game.settings.get("pf2e-jb2a-macros", "debug"))) {
-      const $html = html instanceof jQuery ? html : $(html);
-      const folder = $html.find(
-        `.folder[data-folder-id="${game.folders.get(
-          game.settings.get("pf2e-jb2a-macros", "dummyNPCId-folder")
-        )?.id
-        }"]`
-      );
-      folder.remove();
+      const root = html instanceof HTMLElement ? html : html?.[0];
+      if (!root) return;
+      const folderId = game.folders.get(
+        game.settings.get("pf2e-jb2a-macros", "dummyNPCId-folder")
+      )?.id;
+      if (!folderId) return;
+      root
+        .querySelectorAll(`.folder[data-folder-id="${folderId}"]`)
+        .forEach((el) => el.remove());
     }
   }
 );
@@ -754,7 +755,7 @@ pf2eAnimations.crosshairs = async function crosshairs(
   }
 ) {
   pf2eAnimations.requireModule("warpgate");
-  opts = mergeObject(
+  opts = foundry.utils.mergeObject(
     {
       openSheet: true,
       noCollision: true,
@@ -801,7 +802,7 @@ pf2eAnimations.crosshairs = async function crosshairs(
     rememberControlled: true,
   };
 
-  mergeObject(crosshairConfig, opts.crosshairConfig);
+  foundry.utils.mergeObject(crosshairConfig, opts.crosshairConfig);
 
   crosshairConfig.ogIcon = crosshairConfig.icon;
 

--- a/module/updateMenu.js
+++ b/module/updateMenu.js
@@ -190,67 +190,100 @@ async function generateAutorecUpdateHTML() {
     return html
 }
 
-class autorecUpdateFormApplication extends FormApplication {
-    constructor() {
-        super();
-    }
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+class autorecUpdateFormApplication extends HandlebarsApplicationMixin(ApplicationV2) {
+    static DEFAULT_OPTIONS = {
+        id: "autorecUpdateMenu",
+        classes: ["pf2e-animations", "form"],
+        tag: "form",
+        window: {
+            title: "PF2e Animations Update",
+            contentClasses: ["standard-form"],
+        },
+        position: { width: 600, height: "auto" },
+        actions: {
+            update: autorecUpdateFormApplication._onUpdate,
+            cancel: autorecUpdateFormApplication._onCancel,
+        },
+    };
+
+    static PARTS = {
+        body: {
+            template: "modules/pf2e-jb2a-macros/module/autorecUpdateMenu.html",
+        },
+    };
 
     async html() {
-        return await generateAutorecUpdateHTML()
+        return await generateAutorecUpdateHTML();
     }
 
     async settings() {
-        return await generateAutorecUpdate()
+        return await generateAutorecUpdate();
     }
 
-    static get defaultOptions() {
-        return mergeObject(super.defaultOptions, {
-            classes: ['form'],
-            popOut: true,
-            template: `modules/pf2e-jb2a-macros/module/autorecUpdateMenu.html`,
-            id: 'autorecUpdateMenu',
-            title: 'PF2e Animations Update',
-        });
-    }
-
-    async getData() {
-        // Send data to the template
+    async _prepareContext() {
         return { literallyEverything: await this.html() };
     }
 
-    async activateListeners(html) {
-        const { newSettings, missingEntriesList, updatedEntriesList, customEntriesList, removedEntriesList, blacklistEntriesList } = await this.settings()
-        if (!(
-            missingEntriesList.length
-            || updatedEntriesList.length
-            || customEntriesList.length
-            || removedEntriesList.length
-            || blacklistEntriesList.length
-        )) $('[name="update"]').remove();
-        super.activateListeners(html);
+    async _onRender(context, options) {
+        await super._onRender(context, options);
+        const {
+            missingEntriesList,
+            updatedEntriesList,
+            customEntriesList,
+            removedEntriesList,
+            blacklistEntriesList,
+        } = await generateAutorecUpdate(false);
+        if (
+            !(
+                missingEntriesList.length ||
+                updatedEntriesList.length ||
+                customEntriesList.length ||
+                removedEntriesList.length ||
+                blacklistEntriesList.length
+            )
+        ) {
+            this.element.querySelector('[data-action="update"]')?.remove();
+        }
     }
 
-    async _updateObject(event) {
-        $(".pf2e-animations-autorec-update-buttons").attr("disabled", true)
-        if (event.submitter.name === "update") {
-            console.group("PF2e Animations | Autorecognition Menu Update");
-            const { newSettings, missingEntriesList, updatedEntriesList, customEntriesList, removedEntriesList, blacklistEntriesList } = await this.settings()
-            if (!(
-                missingEntriesList.length
-                || updatedEntriesList.length
-                || customEntriesList.length
-                || removedEntriesList.length
-                || blacklistEntriesList.length
-            )) return console.log("Nothing to update!");
-            /*
-            for (const key of Object.keys(newSettings)) {
-                await game.settings.set('autoanimations', `aaAutorec-${key}`, newSettings[key])
-                console.log(`Updated aaAutorec-${key} with:`, newSettings[key])
-            };
-            */
-            // Passing submitAll: true to ensure menus are updated
-            AutomatedAnimations.AutorecManager.overwriteMenus(JSON.stringify(newSettings), { submitAll: true });
+    static async _onUpdate(event, target) {
+        this.element
+            .querySelectorAll(".pf2e-animations-autorec-update-buttons")
+            .forEach((btn) => (btn.disabled = true));
+        console.group("PF2e Animations | Autorecognition Menu Update");
+        const {
+            newSettings,
+            missingEntriesList,
+            updatedEntriesList,
+            customEntriesList,
+            removedEntriesList,
+            blacklistEntriesList,
+        } = await this.settings();
+        if (
+            !(
+                missingEntriesList.length ||
+                updatedEntriesList.length ||
+                customEntriesList.length ||
+                removedEntriesList.length ||
+                blacklistEntriesList.length
+            )
+        ) {
+            console.log("Nothing to update!");
+            console.groupEnd();
+            return this.close();
         }
+        AutomatedAnimations.AutorecManager.overwriteMenus(
+            JSON.stringify(newSettings),
+            { submitAll: true }
+        );
+        console.groupEnd();
+        return this.close();
+    }
+
+    static async _onCancel(event, target) {
+        return this.close();
     }
 }
 

--- a/templates/blacklist.hbs
+++ b/templates/blacklist.hbs
@@ -84,10 +84,10 @@
     </tr>
     <tr>
       <td>
-        <button id="save">Save</button>
+        <button type="button" id="save" data-action="save">Save</button>
       </td>
       <td>
-        <button id="save-update">Save and Update Animations</button>
+        <button type="button" id="save-update" data-action="saveUpdate">Save and Update Animations</button>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Bring the module up to Foundry v14 by replacing APIs that were removed in the V1 -> V2 transition.

- module.json: bump compatibility to { minimum: 12, verified: 14 }
- pf2e-animations.js:
  * renderChatMessage hook -> renderChatMessageHTML (HTMLElement, not jQuery)
  * renderActorDirectory: drop jQuery polyfill, use native querySelectorAll
  * mergeObject -> foundry.utils.mergeObject
- updateMenu.js + autorecUpdateMenu.html:
  * Port autorecUpdateFormApplication from FormApplication to ApplicationV2 + HandlebarsApplicationMixin
  * Replace getData/activateListeners/_updateObject with _prepareContext/_onRender + DEFAULT_OPTIONS.actions handlers
  * Drop jQuery in favor of querySelector(All) on this.element
- blacklistMenu.js + templates/blacklist.hbs:
  * Same V2 port for BlacklistMenu; buttons now use data-action