### PR TITLE
Replace SoundFx references with PSFX

### DIFF
--- a/animations/melee/backswing.json
+++ b/animations/melee/backswing.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -152,7 +152,7 @@
             "delay": 400,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/melee/bastard-sword.json
+++ b/animations/melee/bastard-sword.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-9.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/club.json
+++ b/animations/melee/club.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 900,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-4.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/dagger-pistol.json
+++ b/animations/melee/dagger-pistol.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/dagger.json
+++ b/animations/melee/dagger.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 500,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Throw%20Hit/throw-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 800,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/explosive-dogslicer.json
+++ b/animations/melee/explosive-dogslicer.json
@@ -35,7 +35,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.impacts.magicaleffects.fire.0",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/fist.json
+++ b/animations/melee/fist.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/flowing-wave.json
+++ b/animations/melee/flowing-wave.json
@@ -63,7 +63,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/gauntlet.json
+++ b/animations/melee/gauntlet.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/glaive.json
+++ b/animations/melee/glaive.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-10.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/greataxe.json
+++ b/animations/melee/greataxe.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-13.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/greatclub.json
+++ b/animations/melee/greatclub.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 900,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-5.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/greatsword.json
+++ b/animations/melee/greatsword.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1500,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-12.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/guisarme.json
+++ b/animations/melee/guisarme.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-10.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/gun-sword.json
+++ b/animations/melee/gun-sword.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/halberd.json
+++ b/animations/melee/halberd.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-12.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/hammer-gun.json
+++ b/animations/melee/hammer-gun.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/hatchet.json
+++ b/animations/melee/hatchet.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Throw%20Hit/throw-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1200,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-10.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/hoof.json
+++ b/animations/melee/hoof.json
@@ -63,7 +63,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/longsword.json
+++ b/animations/melee/longsword.json
@@ -92,7 +92,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-10.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/mace-multipistol.json
+++ b/animations/melee/mace-multipistol.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/mace.json
+++ b/animations/melee/mace.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 800,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-4.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/maul.json
+++ b/animations/melee/maul.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1500,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-4.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/morningstar.json
+++ b/animations/melee/morningstar.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 800,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-4.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/piercing-wind.json
+++ b/animations/melee/piercing-wind.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.musket",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/pseudopod.json
+++ b/animations/melee/pseudopod.json
@@ -63,7 +63,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -121,7 +121,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/melee/ranseur.json
+++ b/animations/melee/ranseur.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-10.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/rapier-pistol.json
+++ b/animations/melee/rapier-pistol.json
@@ -66,7 +66,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/rapier.json
+++ b/animations/melee/rapier.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1200,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/retribution-axe.json
+++ b/animations/melee/retribution-axe.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-13.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/sap.json
+++ b/animations/melee/sap.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/scimitar.json
+++ b/animations/melee/scimitar.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-11.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/shortsword.json
+++ b/animations/melee/shortsword.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1000,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-9.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/sparkblade.json
+++ b/animations/melee/sparkblade.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1000,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-9.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/spiked-gauntlet.json
+++ b/animations/melee/spiked-gauntlet.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/staff.json
+++ b/animations/melee/staff.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1500,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-4.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/sword-cane.json
+++ b/animations/melee/sword-cane.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-12.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/tentacle.json
+++ b/animations/melee/tentacle.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -152,7 +152,7 @@
             "delay": 400,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/melee/throwing-knife.json
+++ b/animations/melee/throwing-knife.json
@@ -35,7 +35,7 @@
         "sound": {
             "delay": 300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Throw%20Hit/throw-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -63,7 +63,7 @@
         "sound": {
             "delay": 800,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/tonfa.json
+++ b/animations/melee/tonfa.json
@@ -94,7 +94,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-4.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/melee/unarmed-strike.json
+++ b/animations/melee/unarmed-strike.json
@@ -26,7 +26,7 @@
             "repeatDelay": 250,
             "startTime": 0,
             "volume": 0.75,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3"
+            "file": "psfx.impacts.bludgeoning.v1"
         },
         "options": {
             "delay": 0,

--- a/animations/melee/unarmed.json
+++ b/animations/melee/unarmed.json
@@ -62,7 +62,7 @@
             "repeatDelay": 250,
             "startTime": 0,
             "volume": 0.75,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3"
+            "file": "psfx.impacts.bludgeoning.v1"
         },
         "options": {
             "delay": 0,

--- a/animations/ontoken/all-encompassing-hunger.json
+++ b/animations/ontoken/all-encompassing-hunger.json
@@ -37,7 +37,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/ontoken/attack-animation-template-(critical-failure).json
+++ b/animations/ontoken/attack-animation-template-(critical-failure).json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Miss/melee-miss-1.mp3",
+            "file": "psfx.weapon-swooshes.light",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -106,7 +106,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Miss/melee-miss-1.mp3",
+            "file": "psfx.weapon-swooshes.light",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/attack-animation-template-(critical-success).json
+++ b/animations/ontoken/attack-animation-template-(critical-success).json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-13.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -106,7 +106,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-13.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/attack-animation-template-(failure).json
+++ b/animations/ontoken/attack-animation-template-(failure).json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Miss/melee-miss-1.mp3",
+            "file": "psfx.weapon-swooshes.light",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -106,7 +106,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Miss/melee-miss-1.mp3",
+            "file": "psfx.weapon-swooshes.light",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/attack-animation-template-(success).json
+++ b/animations/ontoken/attack-animation-template-(success).json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/beard.json
+++ b/animations/ontoken/beard.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/bite.json
+++ b/animations/ontoken/bite.json
@@ -78,7 +78,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/ontoken/biting.json
+++ b/animations/ontoken/biting.json
@@ -78,7 +78,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -136,7 +136,7 @@
             "delay": 400,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/conjure-bullet.json
+++ b/animations/ontoken/conjure-bullet.json
@@ -49,7 +49,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Whoosh/spell-whoosh-4.mp3",
+            "file": "psfx.ranged-magic.generic.missile.only.001",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -107,7 +107,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Whoosh/spell-whoosh-4.mp3",
+            "file": "psfx.ranged-magic.generic.missile.only.001",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/crisis-of-faith.json
+++ b/animations/ontoken/crisis-of-faith.json
@@ -78,7 +78,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Misc/Single/Impact/impact-3.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -137,7 +137,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Misc/Single/Impact/impact-3.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/fang.json
+++ b/animations/ontoken/fang.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/ontoken/final-sacrifice.json
+++ b/animations/ontoken/final-sacrifice.json
@@ -78,7 +78,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-2.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -137,7 +137,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-2.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/flip-chamber.json
+++ b/animations/ontoken/flip-chamber.json
@@ -49,7 +49,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*",
+            "file": "psfx.ranged-weapons.guns.prepare.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -107,7 +107,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*",
+            "file": "psfx.ranged-weapons.guns.prepare.revolver",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/frightful-presence.json
+++ b/animations/ontoken/frightful-presence.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Creatures/Monsters/Angry%20Noises/angry-noises-1.mp3",
+            "file": "psfx.creature.dragons.roar.large",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Creatures/Monsters/Angry%20Noises/angry-noises-1.mp3",
+            "file": "psfx.creature.dragons.roar.large",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/glutton's-jaws.json
+++ b/animations/ontoken/glutton's-jaws.json
@@ -37,7 +37,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/ontoken/jaws.json
+++ b/animations/ontoken/jaws.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 400,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-6.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/ontoken/pinch.json
+++ b/animations/ontoken/pinch.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/reload-magazine.json
+++ b/animations/ontoken/reload-magazine.json
@@ -49,7 +49,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Shield%20Hit/shield-hit-7.mp3",
+            "file": "psfx.ranged-weapons.guns.prepare.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -107,7 +107,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Shield%20Hit/shield-hit-7.mp3",
+            "file": "psfx.ranged-weapons.guns.prepare.revolver",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/reload.json
+++ b/animations/ontoken/reload.json
@@ -107,7 +107,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*",
+            "file": "psfx.ranged-weapons.guns.prepare.revolver",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/sand-form.json
+++ b/animations/ontoken/sand-form.json
@@ -37,7 +37,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/psfx-patreon/library/creature/movement/burrow/001/burrow-ranged-001-05ft-03.ogg",
+            "file": "psfx.creature.movement.burrow.001.ranged.05ft",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/ontoken/shatter.json
+++ b/animations/ontoken/shatter.json
@@ -76,7 +76,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Misc/Single/Impact/impact-3.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -134,7 +134,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Misc/Single/Impact/impact-3.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/ontoken/slam.json
+++ b/animations/ontoken/slam.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-2.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/ontoken/wing-deflection.json
+++ b/animations/ontoken/wing-deflection.json
@@ -47,7 +47,7 @@
         "sound": {
             "delay": 200,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-8.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
             "delay": 200,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-8.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/acid-arrow.json
+++ b/animations/range/acid-arrow.json
@@ -67,7 +67,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/acid-splash.json
+++ b/animations/range/acid-splash.json
@@ -103,7 +103,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Misc/Single/Water%20Splash/water-splash-2.mp3",
+            "file": "psfx.cantrips.acid-splash.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/blunderbuss.json
+++ b/animations/range/blunderbuss.json
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.shotgun",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/bow.json
+++ b/animations/range/bow.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Impact/arrow-impact-*.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -127,7 +127,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/brine-dragon-bolt.json
+++ b/animations/range/brine-dragon-bolt.json
@@ -104,7 +104,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Misc/Single/Water%20Splash/water-splash-2.mp3",
+            "file": "psfx.cantrips.acid-splash.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/crossbow.json
+++ b/animations/range/crossbow.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -105,7 +105,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Impact/arrow-impact-*.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -127,7 +127,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/daikyu.json
+++ b/animations/range/daikyu.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/dart-umbrella.json
+++ b/animations/range/dart-umbrella.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-*.mp3",
+            "file": "psfx.ranged-weapons.longbow.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/dart.json
+++ b/animations/range/dart.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 900,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Melee%20Hit/melee-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/dragon-mouth-pistol.json
+++ b/animations/range/dragon-mouth-pistol.json
@@ -67,7 +67,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.revolver",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/drake-rifle-(acid).json
+++ b/animations/range/drake-rifle-(acid).json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.cantrips.acid-splash.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/drake-rifle-(cold).json
+++ b/animations/range/drake-rifle-(cold).json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.impacts.magicaleffects.cold.0",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/drake-rifle-(electricity).json
+++ b/animations/range/drake-rifle-(electricity).json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.3rd-level-spells.call-lightning.v1.primary",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/drake-rifle-(fire).json
+++ b/animations/range/drake-rifle-(fire).json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.impacts.magicaleffects.fire.0",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/drake-rifle-(poison).json
+++ b/animations/range/drake-rifle-(poison).json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.cantrips.poison-spray.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/duchy-defender.json
+++ b/animations/range/duchy-defender.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.rifle",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/dwarven-scattergun.json
+++ b/animations/range/dwarven-scattergun.json
@@ -67,7 +67,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.shotgun",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.shotgun",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/firearm.json
+++ b/animations/range/firearm.json
@@ -67,7 +67,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.rifle",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -103,7 +103,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Impact/arrow-impact-*.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.rifle",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/flingflenser.json
+++ b/animations/range/flingflenser.json
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.rifle",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/ignition.json
+++ b/animations/range/ignition.json
@@ -128,7 +128,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-3.mp3",
+            "file": "psfx.impacts.magicaleffects.fire.0",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/ranged-combatant.json
+++ b/animations/range/ranged-combatant.json
@@ -127,7 +127,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-1.mp3",
+            "file": "psfx.ranged-magic.generic.projectile.instant.001",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/shobhad-longrifle.json
+++ b/animations/range/shobhad-longrifle.json
@@ -127,7 +127,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Arrow%20Fly-By/arrow-fly-by-3.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.energy-blaster",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/sling.json
+++ b/animations/range/sling.json
@@ -69,7 +69,7 @@
         "sound": {
             "delay": 1300,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Throw%20Hit/throw-hit-1.mp3",
+            "file": "psfx.impacts.bludgeoning.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/range/spoon-gun.json
+++ b/animations/range/spoon-gun.json
@@ -125,7 +125,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-5.mp3",
+            "file": "psfx.ranged-weapons.guns.single-fire.shotgun",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/range/throwing-knife.json
+++ b/animations/range/throwing-knife.json
@@ -105,7 +105,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Combat/Single/Throw%20Hit/throw-hit-1.mp3",
+            "file": "psfx.impacts.slashing.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,

--- a/animations/templatefx/bane.json
+++ b/animations/templatefx/bane.json
@@ -18,7 +18,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/psfx-patreon/library/1st-level-spells/bless/v3/bless-v3-005.ogg",
+            "file": "psfx.1st-level-spells.bless.v3.005",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/templatefx/benediction.json
+++ b/animations/templatefx/benediction.json
@@ -18,7 +18,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/psfx-patreon/library/1st-level-spells/bless/v1/bless-v1-001.ogg",
+            "file": "psfx.1st-level-spells.bless.v1.001",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/templatefx/bless.json
+++ b/animations/templatefx/bless.json
@@ -18,7 +18,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/psfx-patreon/library/1st-level-spells/bless/v2/bless-v2-001.ogg",
+            "file": "psfx.1st-level-spells.bless.v2.001",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/templatefx/discomfiting-whispers.json
+++ b/animations/templatefx/discomfiting-whispers.json
@@ -18,7 +18,7 @@
         "sound": {
             "enable": true,
             "delay": 0,
-            "file": "modules/psfx-patreon/library/cantrips/toll-the-dead/v1/rasping-whispers-001.ogg",
+            "file": "psfx.cantrips.toll-the-dead.rasping-whispers.001",
             "repeat": 1,
             "repeatDelay": 250,
             "startTime": 0,

--- a/animations/templatefx/divine-wrath.json
+++ b/animations/templatefx/divine-wrath.json
@@ -85,7 +85,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Combat/Single/Spell%20Impact/spell-impact-2.mp3",
+            "file": "psfx.impacts.magicaleffects.generic.002.002",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/animations/templatefx/storm-of-vengeance.json
+++ b/animations/templatefx/storm-of-vengeance.json
@@ -26,7 +26,7 @@
         "sound": {
             "delay": 0,
             "enable": true,
-            "file": "modules/soundfxlibrary/Nature/Single/Thunder/thunder-3.mp3",
+            "file": "psfx.cantrips.thunderclap.v1",
             "startTime": 0,
             "volume": 1,
             "repeat": 1,
@@ -84,7 +84,7 @@
             "delay": 0,
             "startTime": 0,
             "volume": 1,
-            "file": "modules/soundfxlibrary/Nature/Single/Thunder/thunder-3.mp3",
+            "file": "psfx.cantrips.thunderclap.v1",
             "repeat": 1,
             "repeatDelay": 250
         }

--- a/build/macros/Bouncing Lightning.js
+++ b/build/macros/Bouncing Lightning.js
@@ -14,7 +14,7 @@ let sequence = new Sequence({ moduleName: "PF2e Animations", softFail: true })
   .sound()
   .volume(0.3)
   .file(
-    "modules/soundfxlibrary/Combat/Single/Spell%20Impact%20Lightning/spell-impact-lightning-3.mp3"
+    "psfx.3rd-level-spells.call-lightning.v1.primary"
   )
   .fadeInAudio(500)
   .fadeOutAudio(500)
@@ -35,7 +35,7 @@ for (let i = 1; i < targetTokens.length; i++) {
     .sound()
     .volume(0.3)
     .file(
-      "modules/soundfxlibrary/Combat/Single/Spell%20Impact%20Lightning/spell-impact-lightning-4.mp3"
+      "psfx.3rd-level-spells.call-lightning.v1.secondary"
     )
     .fadeInAudio(500)
     .fadeOutAudio(500)


### PR DESCRIPTION
## Summary

- replace legacy SoundFxLibrary audio references with PSFX Sequencer database keys
- replace hardcoded PSFX module paths with Sequencer database keys
- map weapon, impact, elemental, firearm, and spell sounds to matching PSFX groups

## Validation

- parsed all 1,091 animation JSON files
- generated the combined autorec payload successfully
- confirmed no SoundFxLibrary or absolute PSFX paths remain in animation and macro sources
- `git diff --check` passes

`npm test` could not start locally because `@actions/core` is not installed; equivalent validation was run directly.